### PR TITLE
move config to external file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+cache/
+dist/
+node_modules/
+temp/
+config.json

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ In Terminal: Type "grunt desktop" and hit enter
 1) **Open "src/main/package.json" and enter some information about your game.**
 YOUR_GAME_NAME
 
-2) **Replace these bits in gruntfile.js with your itch.io details:**
+2) **Copy config.example.json to config.json and replace these bits with your itch.io details:**
 YOUR_ITCH_ACCOUNT/YOUR_ITCH_GAME_URL
 
 3) **Replace the default icons in "src/icons" with your own.**
@@ -116,7 +116,7 @@ steam_appid.txt
 ```
 
 3) **Go into the gruntfile.js file and change "version: '0.13.0-beta7'" to whatever version greenworks is built for.**
-For example, if you downloaded "Greenworks v0.10.0 for NW.js v0.22.3 & Electron v1.7.2 Beta" you'd change it to "version: '0.22.3'". 
+For example, if you downloaded "Greenworks v0.10.0 for NW.js v0.22.3 & Electron v1.7.2 Beta" you'd change it to "version: '0.22.3'".
 These versions MUST match or all your Steam stuff will break.
 
 4) **Run the compiler:**
@@ -136,21 +136,22 @@ Making one app at a time is free, and you can add more with a small monthly fee.
 2) **Then you'll need to add signing keys for ios and android to your account, there's instructions here:**
 http://docs.phonegap.com/phonegap-build/signing (This is probably the hardest part of the entire process.)
 
-3) **When that's done, replace these bits in the gruntfile.js file with your phonegap details:**
-YOUR_APP_ID
-YOUR_EMAIL
-YOUR_PASSWORD
-YOUR_IOS_PASSWORD
-YOUR_ANDROID_PASSWORD
-YOUR_ANDROID_KEYSTORE_PASSWORD
-and change this information in "overrides/phonegap/config.xml"
-YOUR_GAME_NAME
-YOUR_GAME_DESCRIPTION
-YOUR_WEBSITE
-YOUR_EMAIL
+3) **If you have not already copy config.example.json to config.json and replace these bits in the file with your phonegap details:**
+PGAP_YOUR_APP_ID,
+PGAP_YOUR_EMAIL,
+PGAP_YOUR_PASSWORD,
+PGAP_YOUR_IOS_PASSWORD,
+PGAP_YOUR_ANDROID_PASSWORD,
+PGAP_YOUR_ANDROID_KEYSTORE_PASSWORD
+
+4) **Change this information in "overrides/phonegap/config.xml"**
+YOUR_GAME_NAME,
+YOUR_GAME_DESCRIPTION,
+YOUR_WEBSITE,
+YOUR_EMAIL,
 YOUR_NAME
 
-4) **Run the compiler:**
+5) **Run the compiler:**
 On PC: double click "build for phonegap.bat"
 On Mac: double click "build for phonegap.command"
 In Terminal: Type "grunt phonegap" and hit enter
@@ -178,4 +179,5 @@ For mobile, you'll need to use a specific audio plugin that gets bundled into th
 
 **Make sure greenworks.js is included in your HTML for Steam stuff**
 
-## Also if you make something cool let me know about it! 
+**Building on Windows may require you to use a CMD prompt with Administrative privileges.**
+## Also if you make something cool let me know about it!

--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,10 @@
+{
+  "PGAP_YOUR_APP_ID": "123456",
+  "PGAP_YOUR_EMAIL": "mypgapaccount@email",
+  "PGAP_YOUR_PASSWORD": "thepasswordtomyaccount",
+  "PGAP_YOUR_IOS_PASSWORD": "iossigningpassword",
+  "PGAP_YOUR_ANDROID_PASSWORD": "androidsigningpassword",
+  "PGAP_YOUR_ANDROID_KEYSTORE_PASSWORD": "keystorepassword",
+  "YOUR_ITCH_ACCOUNT": "itchusername",
+  "YOUR_ITCH_GAME_URL": "gameuristem"
+}

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -1,4 +1,21 @@
 module.exports = function(grunt) {
+  let config;
+  try {
+    config = JSON.parse(require('fs').readFileSync('./config.json', 'utf8'));
+  } catch (err) {
+    console.warn('Config file not found, see README.md if compliling PhoneGap or Itch');
+    // Use a dummy config object so desktop building doesn't fail.
+    config = {
+      "PGAP_YOUR_APP_ID": "123456",
+      "PGAP_YOUR_EMAIL": "mypgapaccount@email",
+      "PGAP_YOUR_PASSWORD": "thepasswordtomyaccount",
+      "PGAP_YOUR_IOS_PASSWORD": "iossigningpassword",
+      "PGAP_YOUR_ANDROID_PASSWORD": "androidsigningpassword",
+      "PGAP_YOUR_ANDROID_KEYSTORE_PASSWORD": "keystorepassword",
+      "YOUR_ITCH_ACCOUNT": "itchusername",
+      "YOUR_ITCH_GAME_URL": "gameuristem"
+    };
+  }
 
 	grunt.loadNpmTasks('grunt-contrib-clean');
 	grunt.loadNpmTasks('grunt-contrib-compress');
@@ -27,7 +44,7 @@ module.exports = function(grunt) {
 			}
 		},
 
-		// Clears folders before 
+		// Clears folders before
 		clean: {
 			all: ['./dist','./temp'],
 			desktop: ['./dist/desktop','./temp/desktop'],
@@ -104,31 +121,31 @@ module.exports = function(grunt) {
 			build: {
 				 options: {
 					archive: "dist/phonegap.zip",
-					"appId": "YOUR_APP_ID",
+					"appId": `${config.PGAP_YOUR_APP_ID}`,
 					"user": {
-						"email": "YOUR_EMAIL",
-						"password": "YOUR_PASSWORD"
+						"email": `${config.PGAP_YOUR_EMAIL}`,
+						"password": `${config.PGAP_YOUR_PASSWORD}`
 					},
 					download: {
 						ios: 'dist/ios/ios.ipa',
 						android: 'dist/android/android.apk'
 					},
 					keys: {
-						ios: { "password": "YOUR_IOS_PASSWORD" },
-						android: { "key_pw": "YOUR_ANDROID_PASSWORD", "keystore_pw": "YOUR_ANDROID_KEYSTORE_PASSWORD" }
+						ios: { "password": `${config.PGAP_YOUR_IOS_PASSWORD}` },
+						android: { "key_pw": `${config.PGAP_YOUR_ANDROID_PASSWORD}`, "keystore_pw": `${config.PGAP_YOUR_ANDROID_KEYSTORE_PASSWORD}` }
 					}
 				}
 			}
 		},
-		
+
 		exec: {
 			butlerlogin: 	'butler login',
-			butlerwin32: 	'butler push dist/itch/nw/win32 YOUR_ITCH_ACCOUNT/YOUR_ITCH_GAME_URL:win32',
-			butlerwin64: 	'butler push dist/itch/nw/win64 YOUR_ITCH_ACCOUNT/YOUR_ITCH_GAME_URL:win64',
-			butlermac: 		'butler push dist/itch/nw/osx64 YOUR_ITCH_ACCOUNT/YOUR_ITCH_GAME_URL:mac',
-			butlerlinux32: 	'butler push dist/itch/nw/linux32 YOUR_ITCH_ACCOUNT/YOUR_ITCH_GAME_URL:linux32',
-			butlerlinux64: 	'butler push dist/itch/nw/linux64 YOUR_ITCH_ACCOUNT/YOUR_ITCH_GAME_URL:linux64',
-			butlerandroid: 	'butler push dist/android YOUR_ITCH_ACCOUNT/YOUR_ITCH_GAME_URL:android'
+			butlerwin32: 	`butler push dist/itch/nw/win32 ${config.YOUR_ITCH_ACCOUNT}/${config.YOUR_ITCH_GAME_URL}:win32`,
+			butlerwin64: 	`butler push dist/itch/nw/win64 ${config.YOUR_ITCH_ACCOUNT}/${config.YOUR_ITCH_GAME_URL}:win64`,
+			butlermac: 		`butler push dist/itch/nw/osx64 ${config.YOUR_ITCH_ACCOUNT}/${config.YOUR_ITCH_GAME_URL}:mac`,
+			butlerlinux32: 	`butler push dist/itch/nw/linux32 ${config.YOUR_ITCH_ACCOUNT}/${config.YOUR_ITCH_GAME_URL}:linux32`,
+			butlerlinux64: 	`butler push dist/itch/nw/linux64 ${config.YOUR_ITCH_ACCOUNT}/${config.YOUR_ITCH_GAME_URL}:linux64`,
+			butlerandroid: 	`butler push dist/android ${config.YOUR_ITCH_ACCOUNT}/${config.YOUR_ITCH_GAME_URL}:android`
 		}
 
 	})
@@ -145,4 +162,3 @@ module.exports = function(grunt) {
 	grunt.registerTask('runall', ['cleanfolders', 'desktop', 'steam', 'itch', 'phonegapitch']);
 
 };
-


### PR DESCRIPTION
no related issue.
- add config.example.json
- update README.md to reflect use of new file.
- add dummy config to gruntfile.js so builds don't break before creating
config.js.
- add .gitignore to protect against checking config.json to version
control, it has passwords afterall.
- add note about possibly needing admin permissions when building in
Windows.